### PR TITLE
Feat17/[Backend]GitHub Action CI/CD 구현

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,62 @@
+name: Back-End Build & Push New Model
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
+env:
+  PROJECT_ID: ascendant-pad-445604-e1 # GCP 프로젝트 ID
+  REGION: ap-norhteast3               # GCP 리전(서울)
+  ZONE: ap-norhteast3-a               # GCP 존
+  REPOSITORY: model-deploy            # Docker Artifact Registry 레포지토리 이름
+  IMAGE: main                         # Docker 이미지 이름
+  GCE_INSTANCE: gorani-back           # GCE 인스턴스 이름
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Docker build'
+        run: |-
+          docker build \
+            --tag "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA" \
+            new/model_deploy
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.6.0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          token_format: 'access_token'
+
+      - uses: 'docker/login-action@v1'
+        name: 'Docker login'
+        with:
+          registry: '${{ env.REGION }}-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+
+      - name: 'Docker push'
+        run: |-
+          docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA"
+  cd:
+    runs-on: ubuntu-latest
+    needs: [ci]
+    steps:
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.6.0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          token_format: 'access_token'
+      - name: Deploy
+        run: |-
+          gcloud compute instances update-container "$GCE_INSTANCE" \
+            --zone "$ZONE" \
+            --container-image "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA"

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -2,34 +2,62 @@ name: Back-End Build & Push New Model
 on:
   push:
     branches:
-      - Feat17/CI_CD
+      - main
+    paths:
+      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
   pull_request:
     branches:
-      - Feat17/CI_CD
+      - main
+    paths:
+      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
 env:
   PROJECT_ID: ascendant-pad-445604-e1 # GCP 프로젝트 ID
-  REGION: ap-norhteast3               # GCP 리전(서울)
-  ZONE: ap-norhteast3-a               # GCP 존
+  REGION: asia-northeast3               # GCP 리전(서울)
+  ZONE: asia-northeast3-a               # GCP 존
   REPOSITORY: model-deploy            # Docker Artifact Registry 레포지토리 이름
   IMAGE: main                         # Docker 이미지 이름
   GCE_INSTANCE: gorani-back           # GCE 인스턴스 이름
+  GCS_BUCKET: gorani-model-deploy       # GCS 버킷 이름
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Docker build'
-        run: |-
-          docker build \
-            --tag "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA" \
-            new/model_deploy
+
+      # GCP 인증
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0.6.0'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           token_format: 'access_token'
+
+      # Setup gcloud CLI
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'
+      
+      # 현재 디렉토리에 models 폴더 생성
+      - name: 'Create models directory'
+        run: |
+          sudo mkdir -p /app/models
+          sudo chmod 777 /app/models
+
+      # GCS에서 모델 파일 다운로드
+      - name: 'Download model files from GCS'
+        run: |
+          gsutil cp gs://$GCS_BUCKET/house_model.pt /app/models/house_model.pt
+          gsutil cp gs://$GCS_BUCKET/person_model.pt /app/models/person_model.pt
+          gsutil cp gs://$GCS_BUCKET/tree_model.pt /app/models/tree_model.pt
+      
+      # Docker 이미지 빌드
+      - name: 'Docker build'
+        run: |-
+          docker build \
+            --tag "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE:$GITHUB_SHA" \
+            app
 
       - uses: 'docker/login-action@v1'
         name: 'Docker login'
@@ -51,6 +79,7 @@ jobs:
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           token_format: 'access_token'
+      
       - name: Deploy
         run: |-
           gcloud compute instances update-container "$GCE_INSTANCE" \

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -2,12 +2,12 @@ name: Back-End Build & Push New Model
 on:
   push:
     branches:
-      - main
+      - Feat17/CI_CD
     paths:
       - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
   pull_request:
     branches:
-      - main
+      - Feat17/CI_CD
     paths:
       - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
 env:

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -3,13 +3,9 @@ on:
   push:
     branches:
       - Feat17/CI_CD
-    paths:
-      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
   pull_request:
     branches:
       - Feat17/CI_CD
-    paths:
-      - "app/**" # app 폴더와 하위 파일 및 디렉토리에 변경이 있을 때만 트리거
 env:
   PROJECT_ID: ascendant-pad-445604-e1 # GCP 프로젝트 ID
   REGION: ap-norhteast3               # GCP 리전(서울)


### PR DESCRIPTION
## Overview
- main 브랜치의 app 폴더 내에 변경 사항이 있을 시 GitHub Action 진행
  - CI : Google Cloud Storage 버킷에 있는 모델 pt 파일 다운로드 -> app폴더의 Docker Image를 빌드 -> Artifact Registry에 push
  - CD : VM 인스턴스의 컨테이너 Docker Image를 업데이트

## Change Log
- GitHub Action workflow 파일 초기 구현
- GCP 세팅(GCS, Artifact Registry, GCE VM 인스턴스)

## To Reviewer
- main 브런치로 커밋 혹은 pull request를 진행하면 자동으로 실행됩니다.
- http://34.64.252.104:8000/ 에서 접근이 가능합니다.
- 단, 업데이트는 서버 상황에 따라 약 15 분 정도 소요되어 이후 접근이 가능합니다.
- 자세한 내용은 .github/workflows/build-push.yaml에서 확인하실 수 있습니다.

### 남은 작업 사항
- 현재 VM 인스턴스의 용량이 50GB여서 새로운 Docker image(6.29GB)를 8번 정도 업로드하면 용량이 부족해서 업데이트가 되지 않는 문제가 있습니다.
  - airflow를 통해 주기적으로 사용하지 않는 Docker image 삭제 기능 추가 필요
 - main, staging, dev 브랜치와 서버를 나누어 추후 서비스의 장애를 최소화할 수 있음

## Issue Tags
- Closed | Fixed: #17 
- See also: #
